### PR TITLE
ループ変数と同名の変数がループ内で再定義されていたら、そのスコープ以下ではエラーを出ないようにする

### DIFF
--- a/itervar.go
+++ b/itervar.go
@@ -110,6 +110,7 @@ func findUsingIterVarRef(pass *analysis.Pass, stmt ast.Stmt, iterVar *ast.Ident)
 			return false
 		}
 
+		// スコープ内で変数を再定義していたら探索をスキップする
 		s := pass.TypesInfo.Scopes[n]
 		if s != nil {
 			if s.Lookup(iterVar.Obj.Name) != nil {

--- a/itervar.go
+++ b/itervar.go
@@ -114,6 +114,18 @@ func findUsingIterVarRef(pass *analysis.Pass, stmt ast.Stmt, iterVar *ast.Ident)
 			return true
 		}
 		switch n := n.(type) {
+		// 再代入されていてたらそのスコープはスキップする
+		case *ast.AssignStmt:
+			for _, expr := range n.Lhs {
+				expr, ok := expr.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				// TODO ここでfalseを返しても子ノードがスキップされるだけで、同一スコープ内のtraverseはされるので困る
+				if expr.Obj.Kind == ast.Var && expr.Obj.Name == iterVar.Obj.Name {
+					return false
+				}
+			}
 		// &i を検出
 		case *ast.UnaryExpr:
 			x, ok := n.X.(*ast.Ident)

--- a/itervar.go
+++ b/itervar.go
@@ -48,9 +48,7 @@ func checkForStmt(pass *analysis.Pass, forStmt *ast.ForStmt) {
 		return
 	}
 
-	for _, stmt := range forStmt.Body.List {
-		findUsingIterVarRef(pass, stmt, iterVar)
-	}
+	findUsingIterVarRef(pass, forStmt.Body, iterVar)
 }
 
 func checkRangeStmt(pass *analysis.Pass, rangeStmt *ast.RangeStmt) {
@@ -59,9 +57,7 @@ func checkRangeStmt(pass *analysis.Pass, rangeStmt *ast.RangeStmt) {
 		return
 	}
 
-	for _, stmt := range rangeStmt.Body.List {
-		findUsingIterVarRef(pass, stmt, iterVar)
-	}
+	findUsingIterVarRef(pass, rangeStmt.Body, iterVar)
 }
 
 func extractIteratorVariableFromForStmt(forStmt *ast.ForStmt) *ast.Ident {
@@ -111,21 +107,17 @@ func findUsingIterVarRef(pass *analysis.Pass, stmt ast.Stmt, iterVar *ast.Ident)
 
 	ast.Inspect(stmt, func(n ast.Node) bool {
 		if n == nil {
-			return true
+			return false
 		}
-		switch n := n.(type) {
-		// 再代入されていてたらそのスコープはスキップする
-		case *ast.AssignStmt:
-			for _, expr := range n.Lhs {
-				expr, ok := expr.(*ast.Ident)
-				if !ok {
-					return true
-				}
-				// TODO ここでfalseを返しても子ノードがスキップされるだけで、同一スコープ内のtraverseはされるので困る
-				if expr.Obj.Kind == ast.Var && expr.Obj.Name == iterVar.Obj.Name {
-					return false
-				}
+
+		s := pass.TypesInfo.Scopes[n]
+		if s != nil {
+			if s.Lookup(iterVar.Obj.Name) != nil {
+				return false
 			}
+		}
+
+		switch n := n.(type) {
 		// &i を検出
 		case *ast.UnaryExpr:
 			x, ok := n.X.(*ast.Ident)

--- a/testdata/src/ref_to_loop_iter_var/copy_the_loop_variable.go
+++ b/testdata/src/ref_to_loop_iter_var/copy_the_loop_variable.go
@@ -27,3 +27,31 @@ func copyTheLoopVariableButInBlockScope() {
 		fmt.Printf("Value:%d, Address: %p\n", *o, o)
 	}
 }
+
+func rangeCopyTheLoopVariable() {
+	in := []int{1, 2, 3}
+	var out []*int
+	for _, i := range in {
+		i := i // Address values changes every time because it copies the loop variable into a new variable.
+		out = append(out, &i)
+	}
+	for _, o := range out {
+		fmt.Printf("Value:%d, Address: %p\n", *o, o)
+	}
+}
+
+func rangeCopyTheLoopVariableButInBlockScope() {
+	in := []int{1, 2, 3}
+	var out []*int
+	for _, i := range in {
+		{
+			i := i
+			out = append(out, &i)
+		}
+		// Should be detected because this is out of block which copies the loop variable
+		out = append(out, &i) // want "using reference to loop iterator variable"
+	}
+	for _, o := range out {
+		fmt.Printf("Value:%d, Address: %p\n", *o, o)
+	}
+}

--- a/testdata/src/ref_to_loop_iter_var/copy_the_loop_variable.go
+++ b/testdata/src/ref_to_loop_iter_var/copy_the_loop_variable.go
@@ -1,0 +1,29 @@
+package ref_to_loop_iter_var
+
+import "fmt"
+
+func copyTheLoopVariable() {
+	var out []*int
+	for i := 0; i < 3; i++ {
+		i := i // Address values changes every time because it copies the loop variable into a new variable.
+		out = append(out, &i)
+	}
+	for _, o := range out {
+		fmt.Printf("Value:%d, Address: %p\n", *o, o)
+	}
+}
+
+func copyTheLoopVariableButInBlockScope() {
+	var out []*int
+	for i := 0; i < 3; i++ {
+		{
+			i := i
+			out = append(out, &i)
+		}
+		// Should be detected because this is out of block which copies the loop variable
+		out = append(out, &i) // want "using reference to loop iterator variable"
+	}
+	for _, o := range out {
+		fmt.Printf("Value:%d, Address: %p\n", *o, o)
+	}
+}


### PR DESCRIPTION
## What

ループ変数と同名の変数が子スコープ内で再定義されていたら、その子スコープ以下ではエラーを出ないようにしたい。

### Example

```go
func copyTheLoopVariableButInBlockScope() {
	var out []*int
	for i := 0; i < 3; i++ {
		{
			i := i // Address values changes every time because it copies the loop variable into a new variable.
			out = append(out, &i)
		}
		// Should be detected because this is out of block which copies the loop variable
		out = append(out, &i) // want "using reference to loop iterator variable"
	}
	for _, o := range out {
		fmt.Printf("Value:%d, Address: %p\n", *o, o)
	}
}
```


## TODO

現状の実装では、`i` が別スコープで新規に定義されたのをキャッチしても、子ノードの探索がスキップされるだけで兄弟ノード(同一スコープのノード)の探索をスキップすることが出来ない。

やりたいことは、`i` が再定義されたスコープ以下では探索をスキップすることなので、これではうまくテストをパスできない

### 対応
- `ast.Walk` を使う?
- 自分で深さ優先探索のtraverseのコードを書く
- 他に何かないか
- そもそも別の方針でやったほうがいいのか

